### PR TITLE
Handle redirects

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,7 +20,8 @@ module.exports = function(pth, options = defaultOptions) {
 		index: false,
 		ssr: () => (req, res, next) => {
 			if(isRemote && remoteRender.isAsset(req.url)) {
-				return void remoteRender.cache(pth, req, res);
+				let baseUrl = render.url || pth;
+				return void remoteRender.cache(baseUrl, req, res);
 			}
 
 			let stream = render(req);

--- a/lib/remote-render.js
+++ b/lib/remote-render.js
@@ -1,15 +1,17 @@
 const dom = require("can-zone-jsdom");
 const fetch = require("node-fetch");
 const localCache = require("./local-cache");
-const path = require("path");
 const {Readable, Writable} = require("stream");
 const ssr = require("done-ssr");
 
 exports = module.exports = function(url) {
-	let pagePromise = loadPage(url);
+	let pagePromise = loadPage(url).then(response => {
+		renderer.url = response.url;
+		return response.html;
+	})
 	let render;
 
-	return function(request) {
+	let renderer = function(request) {
 		if(render) {
 			return render(request);
 		}
@@ -34,6 +36,8 @@ exports = module.exports = function(url) {
 		});
 	};
 
+	return renderer;
+
 	function createRender(html, url) {
 		let domOptions = {
 			html,
@@ -46,14 +50,27 @@ exports = module.exports = function(url) {
 	}
 };
 
-async function loadPage(url) {
-	let res = await fetch(url);
-	if(!res.ok) {
-		throw res.status;
-	}
-	let html = await res.text();
+async function loadPage(url, follows = 0) {
+	let res = await fetch(url, {
+		redirect: 'manual'
+	});
+	
+	if(res.status === 301 || res.status === 302) {
+		if(follows > 5) {
+			throw new Error('Too many redirects.');
+		}
 
-	return html;
+		let location = res.headers.get('location');
+		return loadPage(location, follows++);
+	}
+
+	if(!res.ok) {
+		throw new Error(res.status);
+	}
+
+	let html = await res.text();
+	
+	return { html, url };
 }
 
 exports.cacheDir = localCache.dir;


### PR DESCRIPTION
This makes it so we can handle redirects caused by the page URL having
redirects. Now we will correctly use the final URL when loading external
assets as well. Closes #19